### PR TITLE
Disabling chaincode access control only in dev mode

### DIFF
--- a/chaincode/README.md
+++ b/chaincode/README.md
@@ -15,11 +15,40 @@ From root directory of project, run `make chaincode_test`
 # Run Chaincode in Net Mode
 In this mode, your chaincode will be installed and invoked as part of a larger distributed application.   
 
-Follow instructions in [network](../network/), [middleware](../middleware/), and [application](../application) in sequence.
+## Prerequisites
+- Make sure that access control is **enabled** within the chaincode by setting the value of `TradeWorkflowChaincode.testMode` to `false`.
+  * In both [trade_workflow/tradeWorkflow.go](./src/github.com/trade_workflow/tradeWorkflow.go) and [trade_workflow_v1/tradeWorkflow.go](./src/github.com/trade_workflow_v1/tradeWorkflow.go), this is set in the `main` function as follows:
+    ```
+	func main() {
+		twc := new(TradeWorkflowChaincode)
+		twc.testMode = false
+		err := shim.Start(twc)
+		if err != nil {
+			fmt.Printf("Error starting Trade Workflow chaincode: %s", err)
+		}
+	}
+    ```
+
+## Launch the Network and Application
+- Follow instructions in [network](../network/), [middleware](../middleware/), and [application](../application) in sequence.
 
 
 # Run Chaincode in Dev Mode
-In tnis mode, you will manually install and invoke the chaincode using CLI (Command-Line Interface) commands.   
+In this mode, you will manually install and invoke the chaincode using CLI (Command-Line Interface) commands.   
+
+## Prerequisites
+- Make sure that access control is **disabled** within the chaincode by setting the value of `TradeWorkflowChaincode.testMode` to `true`.
+  * In both [trade_workflow/tradeWorkflow.go](./src/github.com/trade_workflow/tradeWorkflow.go) and [trade_workflow_v1/tradeWorkflow.go](./src/github.com/trade_workflow_v1/tradeWorkflow.go), this is set in the `main` function as follows:
+    ```
+	func main() {
+		twc := new(TradeWorkflowChaincode)
+		twc.testMode = true
+		err := shim.Start(twc)
+		if err != nil {
+			fmt.Printf("Error starting Trade Workflow chaincode: %s", err)
+		}
+	}
+    ```
 
 ## Start the Blockchain Network
 - Navigate to the [network](../network/) folder and run `./trade.sh up -d true`.

--- a/chaincode/src/github.com/trade_workflow_v1/tradeWorkflow.go
+++ b/chaincode/src/github.com/trade_workflow_v1/tradeWorkflow.go
@@ -1318,7 +1318,7 @@ func (t *TradeWorkflowChaincode) getAccountBalance(stub shim.ChaincodeStubInterf
 
 func main() {
 	twc := new(TradeWorkflowChaincode)
-	twc.testMode = true
+	twc.testMode = false
 	err := shim.Start(twc)
 	if err != nil {
 		fmt.Printf("Error starting Trade Workflow chaincode: %s", err)

--- a/network/devmode/docker-compose-e2e-template.yaml
+++ b/network/devmode/docker-compose-e2e-template.yaml
@@ -106,11 +106,11 @@ services:
       - CORE_PEER_LOCALMSPID=DevOrgMSP
       - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp
     working_dir: /opt/gopath/src/chaincode
-    command: /bin/bash -c 'sleep 600000'
+    command: /bin/bash -c 'cp -r /opt/gopath/src/chaincode_copy/* /opt/gopath/src/chaincode/ && sed -i "s/twc\.testMode = false/twc\.testMode = true/g" /opt/gopath/src/chaincode/trade_workflow_v1/tradeWorkflow.go && sleep 600000'
     volumes:
         - /var/run/:/host/var/run/
         - ./crypto-config/peerOrganizations/devorg.trade.com/peers/peer0.devorg.trade.com/msp:/etc/hyperledger/msp
-        - ./../../chaincode/src/github.com:/opt/gopath/src/chaincode
+        - ./../../chaincode/src/github.com:/opt/gopath/src/chaincode_copy
     depends_on:
       - orderer
       - peer


### PR DESCRIPTION
Mapped chaincode to temporary location in container
Switched the access control (`testMode`) flag in the source after copying chaincode to the run location
Enabled access control in `v1` source code (reverting change in https://github.com/HyperledgerHandsOn/trade-finance-logistics/commit/284ea59fb74774d1e257be943747784c7421f102)
Added instructions for manual enabling and disabling of access control in chaincode in net and dev modes