### PR TITLE
Pegging Fabric npm packages in middleware to v1.1

### DIFF
--- a/middleware/package.json
+++ b/middleware/package.json
@@ -4,8 +4,8 @@
   "description": "Trade Use Case",
   "main": "app.js",
   "dependencies": {
-    "fabric-ca-client": "^1.1.0",
-    "fabric-client": "^1.1.0",
+    "fabric-ca-client": "~1.1.0",
+    "fabric-client": "~1.1.0",
     "fs-extra": "^2.0.0",
     "jsrsasign": "6.2.2",
     "tape": "^4.5.1",


### PR DESCRIPTION
This is needed because the default version has advanced to v1.2