### PR TITLE
Fix panic under fabric 1.2

### DIFF
--- a/network/configtx.yaml
+++ b/network/configtx.yaml
@@ -16,44 +16,6 @@
 
 ################################################################################
 #
-#   Profile
-#
-#   - Different configuration profiles may be encoded here to be specified
-#   as parameters to the configtxgen tool
-#
-################################################################################
-Profiles:
-
-    FourOrgsTradeOrdererGenesis:
-        Capabilities:
-            <<: *ChannelCapabilities
-        Orderer:
-            <<: *OrdererDefaults
-            Organizations:
-                - *TradeOrdererOrg
-            Capabilities:
-                <<: *OrdererCapabilities
-        Consortiums:
-            TradeConsortium:
-                Organizations:
-                    - *ExporterOrg
-                    - *ImporterOrg
-                    - *CarrierOrg
-                    - *RegulatorOrg
-    FourOrgsTradeChannel:
-        Consortium: TradeConsortium
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - *ExporterOrg
-                - *ImporterOrg
-                - *CarrierOrg
-                - *RegulatorOrg
-            Capabilities:
-                <<: *ApplicationCapabilities
-
-################################################################################
-#
 #   Section: Organizations
 #
 #   - This section defines the different organizational identities which will
@@ -250,3 +212,41 @@ Capabilities:
         # modification of which would cause incompatibilities.  Users should
         # leave this flag set to true.
         V1_1: true
+
+################################################################################
+#
+#   Profile
+#
+#   - Different configuration profiles may be encoded here to be specified
+#   as parameters to the configtxgen tool
+#
+################################################################################
+Profiles:
+
+    FourOrgsTradeOrdererGenesis:
+        Capabilities:
+            <<: *ChannelCapabilities
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+                - *TradeOrdererOrg
+            Capabilities:
+                <<: *OrdererCapabilities
+        Consortiums:
+            TradeConsortium:
+                Organizations:
+                    - *ExporterOrg
+                    - *ImporterOrg
+                    - *CarrierOrg
+                    - *RegulatorOrg
+    FourOrgsTradeChannel:
+        Consortium: TradeConsortium
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+                - *ExporterOrg
+                - *ImporterOrg
+                - *CarrierOrg
+                - *RegulatorOrg
+            Capabilities:
+                <<: *ApplicationCapabilities

--- a/network/devmode/configtx.yaml
+++ b/network/devmode/configtx.yaml
@@ -16,38 +16,6 @@
 
 ################################################################################
 #
-#   Profile
-#
-#   - Different configuration profiles may be encoded here to be specified
-#   as parameters to the configtxgen tool
-#
-################################################################################
-Profiles:
-
-    OneOrgTradeOrdererGenesis:
-        Capabilities:
-            <<: *ChannelCapabilities
-        Orderer:
-            <<: *OrdererDefaults
-            Organizations:
-                - *TradeOrdererOrg
-            Capabilities:
-                <<: *OrdererCapabilities
-        Consortiums:
-            TradeConsortium:
-                Organizations:
-                    - *DevOrg
-    OneOrgTradeChannel:
-        Consortium: TradeConsortium
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - *DevOrg
-            Capabilities:
-                <<: *ApplicationCapabilities
-
-################################################################################
-#
 #   Section: Organizations
 #
 #   - This section defines the different organizational identities which will
@@ -193,3 +161,35 @@ Capabilities:
         # modification of which would cause incompatibilities.  Users should
         # leave this flag set to true.
         V1_1: true
+
+################################################################################
+#
+#   Profile
+#
+#   - Different configuration profiles may be encoded here to be specified
+#   as parameters to the configtxgen tool
+#
+################################################################################
+Profiles:
+
+    OneOrgTradeOrdererGenesis:
+        Capabilities:
+            <<: *ChannelCapabilities
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+                - *TradeOrdererOrg
+            Capabilities:
+                <<: *OrdererCapabilities
+        Consortiums:
+            TradeConsortium:
+                Organizations:
+                    - *DevOrg
+    OneOrgTradeChannel:
+        Consortium: TradeConsortium
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+                - *DevOrg
+            Capabilities:
+                <<: *ApplicationCapabilities


### PR DESCRIPTION
While running `./trade.sh -d true` under `fabric 1.2`, I got this panic: `unknown anchor 'ChannelCapabilities' referenced`, and got it fixed according to https://stackoverflow.com/questions/51195016/hyperledger-configtxgen-error