### PR TITLE
fix error launching trade.sh in dev mode

### DIFF
--- a/network/devmode/.env
+++ b/network/devmode/.env
@@ -1,0 +1,2 @@
+COMPOSE_PROJECT_NAME=net
+IMAGE_TAG=latest

--- a/network/devmode/configtx.yaml
+++ b/network/devmode/configtx.yaml
@@ -16,38 +16,6 @@
 
 ################################################################################
 #
-#   Profile
-#
-#   - Different configuration profiles may be encoded here to be specified
-#   as parameters to the configtxgen tool
-#
-################################################################################
-Profiles:
-
-    OneOrgTradeOrdererGenesis:
-        Capabilities:
-            <<: *ChannelCapabilities
-        Orderer:
-            <<: *OrdererDefaults
-            Organizations:
-                - *TradeOrdererOrg
-            Capabilities:
-                <<: *OrdererCapabilities
-        Consortiums:
-            TradeConsortium:
-                Organizations:
-                    - *DevOrg
-    OneOrgTradeChannel:
-        Consortium: TradeConsortium
-        Application:
-            <<: *ApplicationDefaults
-            Organizations:
-                - *DevOrg
-            Capabilities:
-                <<: *ApplicationCapabilities
-
-################################################################################
-#
 #   Section: Organizations
 #
 #   - This section defines the different organizational identities which will
@@ -193,3 +161,35 @@ Capabilities:
         # modification of which would cause incompatibilities.  Users should
         # leave this flag set to true.
         V1_1: true
+
+################################################################################
+#
+#   Profile
+#
+#   - Different configuration profiles may be encoded here to be specified
+#   as parameters to the configtxgen tool
+#
+################################################################################
+Profiles:
+
+    OneOrgTradeOrdererGenesis:
+        Capabilities:
+            <<: *ChannelCapabilities
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+                - *TradeOrdererOrg
+            Capabilities:
+                <<: *OrdererCapabilities
+        Consortiums:
+            TradeConsortium:
+                Organizations:
+                    - *DevOrg
+    OneOrgTradeChannel:
+        Consortium: TradeConsortium
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+                - *DevOrg
+            Capabilities:
+                <<: *ApplicationCapabilities

--- a/network/devmode/docker-compose-e2e-template.yaml
+++ b/network/devmode/docker-compose-e2e-template.yaml
@@ -51,7 +51,8 @@ services:
         - /var/run/:/host/var/run/
         - ./crypto-config/peerOrganizations/devorg.trade.com/peers/peer0.devorg.trade.com/msp:/etc/hyperledger/msp
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
-    command: peer node start --peer-chaincodedev=true -o orderer:7050
+    # command: peer node start --peer-chaincodedev -o "orderer:7050"
+    command: peer node start --peer-chaincodedev
     ports:
       - 7051:7051
       - 7053:7053

--- a/network/devmode/docker-compose-e2e-template.yaml
+++ b/network/devmode/docker-compose-e2e-template.yaml
@@ -51,7 +51,6 @@ services:
         - /var/run/:/host/var/run/
         - ./crypto-config/peerOrganizations/devorg.trade.com/peers/peer0.devorg.trade.com/msp:/etc/hyperledger/msp
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
-    # command: peer node start --peer-chaincodedev -o "orderer:7050"
     command: peer node start --peer-chaincodedev
     ports:
       - 7051:7051


### PR DESCRIPTION
When launching trade.sh in dev mode, following errors prevent proper launch of the containers:
- IMAGE_TAG is missing.
- in configtx.yaml, Profiles is before Capabilities, so ChannelCapabilities is declared below its use.
- when cli container tries to launch peer (peer node start), error saying that flag "-o" or flag "--orderer" is not known. I don't know why. But anyway, from [here](https://hyperledger-fabric.readthedocs.io/en/release-1.3/commands/peernode.html) it seems that "orderer:7050" is the default.

(I made the PR on the branch release-1.2 instead of master as that branch is further)