### PR TITLE
Readme.md update - fixing a typo

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -27,8 +27,8 @@ Our application code is based on the current Hyperledger Fabric release version 
   * `cd fabric`
   * If the default branch is not `release-1.2`, append `-b release-1.2` to the above command
   * Run `make configtxgen cryptogen configtxlator` to build the tools we will use to create configuration files.
-    * Binaries can be found under `build/bin`
-    * Either move the binaries to a path such as `/usr/local/bin` or add the `$GOPATH/src/github.com/hyperledger/fabric/build/bin` to the PATH environment variable.
+    * Binaries can be found under `.build/bin`
+    * Either move the binaries to a path such as `/usr/local/bin` or add the `$GOPATH/src/github.com/hyperledger/fabric/.build/bin` to the PATH environment variable.
   * Run `make docker` to build docker images for the various network components from the downloaded source code.
 - Download and build [Fabric-CA](https://github.com/hyperledger/fabric-ca/):
   * `git clone https://github.com/hyperledger/fabric-ca/` (`release-1.2` branch as above)


### PR DESCRIPTION
directory is .build/bin, not build/bin